### PR TITLE
🐛 名前もチャンネル名もnull(非公開)の場合にエラーになるバグの修正

### DIFF
--- a/src/niconico/NicoPlayer.tsx
+++ b/src/niconico/NicoPlayer.tsx
@@ -12,7 +12,8 @@ const NicoPlayer: React.FunctionComponent = () => {
     if (initialWatchData !== undefined) {
       const nickname =
         initialWatchData?.data.owner?.nickname ??
-        initialWatchData?.data.channel.name;
+        initialWatchData?.data.channel.name ??
+        "UNKNOWN";
 
       void trimArtWork(
         String(initialWatchData?.data.video.thumbnail.player)


### PR DESCRIPTION
#12 